### PR TITLE
Switched to JSON from CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img src="https://github.com/Youfront/statamic-export/blob/main/assets/explainer-video.gif?raw=true">
 </p>
 
-This plugin easily exports your entries to CSV. Select the entries you like to export, and select "Export" from the actions.
+This plugin easily exports your entries to JSON. Select the entries you like to export, and select "Export" from the actions.
 
 ## Installation
 Add the package using composer. And you're done! 😎
@@ -11,5 +11,5 @@ Add the package using composer. And you're done! 😎
 composer require youfront/statamic-export
 ```
 
-# License 
+# License
 This plugin is published under the MIT license. Feel free to use it and remember to spread love 😍

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,7 @@
     "name": "youfront/statamic-export",
     "description": "Statamic Export",
     "require": {
-        "statamic/cms": "^3.0.0",
-        "league/csv": "^9.0.0"
+        "statamic/cms": "^3.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Export.php
+++ b/src/Export.php
@@ -6,81 +6,31 @@ use Carbon\Carbon;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use League\Csv\Writer;
 use Statamic\Actions\Action;
 
 class Export extends Action
 {
     /**
-     * Download items as CSV.
+     * Download items as JSON.
      *
      * @param $items
      * @param $values
      * @return false|Response
-     * @throws \League\Csv\CannotInsertRecord
      */
     public function download($items, $values)
     {
-        $headers = $this::getHeaders($items);
-        $entries = $this::getEntries($headers, $items);
+        $data = $items->map(function($item) {
+            return $item->data();
+        });
 
-        $csv = Writer::createFromString('');
-        $csv->insertOne($headers->toArray());
-        $csv->insertAll($entries->toArray());
-
-        return new Response($csv->getContent(), 200, [
-            'Content-Disposition' => 'attachment; filename="' . $this::getFileName() . '"',
-        ]);
+        return response()
+            ->json($data)
+            ->header('Content-Disposition', 'attachment; filename="' . $this::getFileName() . '"');
     }
 
     public function authorize($user, $item)
     {
         return $user->can('view', $item);
-    }
-
-    /**
-     * Get array keys as headers.
-     *
-     * @param Collection $items
-     *
-     * @return Collection
-     */
-    private static function getHeaders(Collection $items)
-    {
-        $headers = new Collection;
-
-        foreach ($items as $item) {
-            foreach ($item->data()->keys() as $key) {
-                $headers->push($key);
-            }
-        }
-
-        return $headers = $headers->unique();
-    }
-
-    /**
-     * Get entries values by headers.
-     *
-     * @param Collection $headers
-     * @param Collection $items
-     *
-     * @return Collection
-     */
-    private static function getEntries(Collection $headers, Collection $items)
-    {
-        $data = new Collection;
-
-        foreach ($items as $item) {
-            $itemData = [];
-
-            foreach ($headers as $header) {
-                Arr::set($itemData, $header, Arr::get($item->data(), $header));
-            }
-
-            $data->push($itemData);
-        }
-
-        return $data;
     }
 
     /**
@@ -90,6 +40,6 @@ class Export extends Action
      */
     private static function getFileName()
     {
-        return sprintf('Export %s.csv', Carbon::now()->toDateTimeString());
+        return sprintf('Export %s.json', Carbon::now()->toDateTimeString());
     }
 }


### PR DESCRIPTION
Using the JSON format will solve the issues with CSV and the 1NF (#2). The JSON format is more human-readable and more flexible, it can represent any data structure Laravel uses. I don't know if this a viable direction for the project, but I made these changes for personal use and then wondered if they could be of any use.