### PR TITLE
solved Array to string conversion error (caused by bard field)

### DIFF
--- a/src/Export.php
+++ b/src/Export.php
@@ -99,6 +99,11 @@ class Export extends Action
             $itemData = [];
 
             foreach ($headers as $header) {
+                if (is_array($item->$header)) {
+                    Arr::set($itemData, $header, json_encode($item->$header));
+                    continue;
+                }
+
                 Arr::set($itemData, $header, $item->$header);
             }
 


### PR DESCRIPTION
This pull request solves #2 issue

**Why does the problem happen?**
The collection may contain bard field types.
`Arr::get($item->data(), $header)` returns the content in an array format for bard fields (see the example below).

**How the problem was solved?**
instead of `Arr::get($item->data(), $header)` the package will use `$item->$header`
[read more about Getting Field Data in Statamic here](https://statamic.dev/extending/data#getting-field-data)

Before:
`Arr::get($item->data(), $header)`
```
[
    [
        "type" => "paragraph",
        "content" => [
            [
                "type" => "text",
                "text" => "lorem ipsum text here"
            ],
        ],
    ],
]
````
After:
 `$item->$header`
```
<p>lorem ipsum text here</p>
```
**Note:** i think it may still break with the same error for repeater field type or relationship field :(

**What else was added?**
`$csv->getContent()` -> `$csv->toString()` because `getContent` is deprecated and method will be removed in the next major point release
`EXCLUDED_COLUMNS` - it makes no sense to export updated_by and blueprint
`$headers->push('id');` - id to export
