### PR TITLE
Export as CSV, XLSX or JSON, specified by configuration file with defaults and per Collection configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@
 This plugin easily exports your entries to CSV. Select the entries you like to export, and select "Export" from the actions.
 
 ## Installation
-Add the package using composer. And you're done! 😎
+Add the package using composer.
 ```bash
 composer require youfront/statamic-export
+```
+
+Publish the configuration file. And you're done! 😎
+```bash
+php artisan vendor:publish --tag=statamic-export-config
 ```
 
 # License 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "Statamic Export",
     "require": {
         "statamic/cms": "^3.0.0",
-        "league/csv": "^9.0.0"
+        "league/csv": "^9.0.0",
+        "maatwebsite/excel": "^3.1"
     },
     "autoload": {
         "psr-4": {

--- a/config/statamic-export.php
+++ b/config/statamic-export.php
@@ -1,0 +1,14 @@
+<?php
+
+// either: csv, json, xlsx
+
+return [
+    'default' => 'csv',
+    'collections' => [
+        // 'collection_name' => 'xlsx'
+    ],
+    'excluded_columns' => [
+        'blueprint',
+        'updated_by',
+    ]
+];

--- a/src/ArrayExport.php
+++ b/src/ArrayExport.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Youfront\Export;
+
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+
+class ArrayExport implements FromArray, WithHeadings
+{
+    protected $headings;
+    protected $entries;
+
+    public function __construct(array $headings, array $entries)
+    {
+        $this->headings = $headings;
+        $this->entries = $entries;
+    }
+
+    public function array(): array
+    {
+        return $this->entries;
+    }
+
+    public function headings(): array
+    {
+        return $this->headings;
+    }
+}

--- a/src/Export.php
+++ b/src/Export.php
@@ -12,6 +12,7 @@ use League\Csv\Writer;
 use Maatwebsite\Excel\Facades\Excel;
 use Statamic\Actions\Action;
 use Statamic\Entries\Entry;
+use Statamic\Forms\Submission;
 use Throwable;
 
 class Export extends Action
@@ -102,7 +103,7 @@ class Export extends Action
 
     public function visibleTo($item)
     {
-        return $item instanceof Entry;
+        return $item instanceof Entry || $item instanceof Submission;
     }
 
     /**

--- a/src/Export.php
+++ b/src/Export.php
@@ -34,7 +34,11 @@ class Export extends Action
      */
     public function download($items, $values)
     {
-        $export_type = $this::getExportType();
+        try {
+            $export_type = config("statamic-export.collections.{$items[0]->collection->handle}", config("statamic-export.default", "csv"));
+        } catch (Throwable $t) {
+            $export_type = config("statamic-export.default", "csv");
+        }
 
         $headers = $this::getHeaders($items);
         $entries = $this::getEntries($headers, $items);
@@ -132,15 +136,5 @@ class Export extends Action
     private static function getFileName($export_type)
     {
         return sprintf('Export %s.%s', Carbon::now()->toDateTimeString(), $export_type);
-    }
-
-    private static function getExportType()
-    {
-        try {
-            $export_type = config("statamic-export.collections.{$items[0]->collection->handle}", config("statamic-export.default", "csv"));
-        } catch (Throwable $t) {
-            $export_type = config("statamic-export.default", "csv");
-        }
-        return $export_type;
     }
 }

--- a/src/Export.php
+++ b/src/Export.php
@@ -11,6 +11,7 @@ use League\Csv\Exception;
 use League\Csv\Writer;
 use Maatwebsite\Excel\Facades\Excel;
 use Statamic\Actions\Action;
+use Statamic\Entries\Entry;
 use Throwable;
 
 class Export extends Action
@@ -97,6 +98,11 @@ class Export extends Action
         }
 
         return $headers = $headers->unique();
+    }
+
+    public function visibleTo($item)
+    {
+        return $item instanceof Entry;
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,6 +8,12 @@ class ServiceProvider extends AddonServiceProvider
 {
     public function register()
     {
+        $this->mergeConfigFrom(__DIR__ . '/../config/statamic-export.php', 'statamic-export');
+
+        $this->publishes([
+            __DIR__ . '/../config/statamic-export.php' => config_path('statamic-export.php'),
+        ], 'statamic-export-config');
+
         Export::register();
     }
 }


### PR DESCRIPTION
- Adds a configuration file where a default and per collection method of export can be specified
- Adds ability to export as JSON (from #3)
- Adds ability to export as XLSX (using maatwebsite/excel, set as new composer requirement)
- Excluded columns moved to configuration file